### PR TITLE
Add support for generating a java gem.

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -5,6 +5,7 @@ require File.dirname(__FILE__) + "/lib/bond/version"
 Gem::Specification.new do |s|
   s.name        = "bond"
   s.version     = Bond::VERSION
+  s.platform    = ENV['GEM_PLATFORM'] if ENV['GEM_PLATFORM']
   s.authors     = ["Gabriel Horner"]
   s.email       = "gabriel.horner@gmail.com"
   s.homepage    = "http://tagaholic.me/bond/"
@@ -18,8 +19,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha', '>= 0.9.8'
   s.add_development_dependency 'mocha-on-bacon'
   s.add_development_dependency 'bacon-bits'
-  s.files = Dir.glob(%w[{lib,test}/**/*.rb bin/* [A-Z]*.{txt,rdoc} ext/**/*.{rb,c} **/deps.rip]) + %w{Rakefile .gemspec}
+  s.files = Dir.glob(%w[{lib,test}/**/*.rb bin/* [A-Z]*.{txt,rdoc} **/deps.rip]) + %w{Rakefile .gemspec}
+  if ENV['GEM_PLATFORM'] != 'java'
+    s.files += Dir.glob("ext/**/*.{rb,c}")
+    s.extensions = ["ext/readline_line_buffer/extconf.rb"]
+  end
   s.extra_rdoc_files = ["README.rdoc", "LICENSE.txt"]
-  s.extensions = ["ext/readline_line_buffer/extconf.rb"]
   s.license = 'MIT'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,16 +5,28 @@ def gemspec
   @gemspec ||= eval(File.read('.gemspec'), binding, '.gemspec')
 end
 
+def gem_file
+  "#{gemspec.name}-#{gemspec.version}#{ENV['GEM_PLATFORM'] == 'java' ? '-java' : ''}.gem"
+end
+
 desc "Build the gem"
 task :gem=>:gemspec do
   sh "gem build .gemspec"
   FileUtils.mkdir_p 'pkg'
-  FileUtils.mv "#{gemspec.name}-#{gemspec.version}.gem", 'pkg'
+  FileUtils.mv gem_file, 'pkg'
+end
+
+desc "Build gems for the default and java platforms"
+task :all_gems => :gem do
+  ENV['GEM_PLATFORM'] = 'java'
+  @gemspec = nil
+  Rake::Task["gem"].reenable
+  Rake::Task["gem"].invoke
 end
 
 desc "Install the gem locally"
 task :install => :gem do
-  sh %{gem install pkg/#{gemspec.name}-#{gemspec.version}}
+  sh %{gem install pkg/#{gem_file}}
 end
 
 desc "Generate the gemspec"


### PR DESCRIPTION
All of the existing gem related rake tasks should do the right thing for a
java gem if ENV['GEM_VERSION'] == 'java'. There is also an additional rake
task (all_gems) which generates gems for the default and java platforms in
one shot.
