### PR TITLE
Complete `load` as with `require`

### DIFF
--- a/lib/bond/completions/kernel.rb
+++ b/lib/bond/completions/kernel.rb
@@ -4,8 +4,10 @@ complete(:methods=>%w{Kernel#system Kernel#exec}) {|e|
     File.directory?(e) ? Dir.entries(e) : []
   }.flatten.uniq - ['.', '..']
 }
-complete(:method=>"Kernel#require", :search=>:files) {
-  paths = $:.map {|e| Dir["#{e}/**/*.{rb,bundle,dll,so}"].map {|f| f.sub(e+'/', '') } }.flatten
+complete(:methods=>%w{Kernel#require Kernel#load}, :search=>:files) {
+  paths = $:.map do |e|
+    Dir["#{e}/**/*.{rb,bundle,dll,so}"].map {|f| f.sub(e+'/', '') }
+  end.flatten
   if Object.const_defined?(:Gem)
     paths += Gem.path.map {|e| Dir["#{e}/gems/*/lib/*.{rb,bundle,dll,so}"].
       map {|f| f.sub(/^.*\//,'') } }.flatten

--- a/test/completions_test.rb
+++ b/test/completions_test.rb
@@ -34,11 +34,13 @@ describe "completions for" do
       tab("raise Errno::ETIME").sort.should == %w{Errno::ETIME Errno::ETIMEDOUT}
     end
 
-    it "#require" do
+    it "#require and #load" do
       mock_libs = ['net/http.rb', 'net/http/get.rb', 'abbrev.rb'].map {|e| $:[0] + "/#{e}" }
       Dir.stubs(:[]).returns(mock_libs)
       tab("require 'net/htt").should == %w{net/http.rb net/http/}
+      tab("load 'net/htt").should == %w{net/http.rb net/http/}
     end
+
   end
 
   describe "Object" do


### PR DESCRIPTION
Addresses #19.

Next up, I want to make it so it respects `./` so you can do: `load './lib/<tab><tab>'`
