### PR TITLE
Jruby repeatability

### DIFF
--- a/lib/bond/readlines/jruby.rb
+++ b/lib/bond/readlines/jruby.rb
@@ -4,7 +4,7 @@ class Bond::Jruby < Bond::Readline
     require 'readline'
     require 'jruby'
     class << Readline
-      ReadlineExt = org.jruby.ext.Readline
+      ReadlineExt ||= org.jruby.ext.Readline
       def line_buffer
         ReadlineExt.s_get_line_buffer(JRuby.runtime.current_context, JRuby.reference(self))
       end


### PR DESCRIPTION
Our use in the git version of Pry was causing warnings. I don't really think this is Bond's fault, but it might as well be a bit fault-tolerant in not letting this constant be reinitialized.
