### PR TITLE
ruby 2.0 support [Fixes #20] [Fixes #21]

### DIFF
--- a/lib/bond/mission.rb
+++ b/lib/bond/mission.rb
@@ -53,8 +53,8 @@ module Bond
     attr_reader :on
     # Takes same options as {Bond#complete}.
     def initialize(options)
-      raise InvalidMissionError, ":action" unless (options[:action] || respond_to?(:default_action))
-      raise InvalidMissionError, ":on" unless (options[:on] && options[:on].is_a?(Regexp)) || respond_to?(:default_on)
+      raise InvalidMissionError, ":action" unless (options[:action] || respond_to?(:default_action, true))
+      raise InvalidMissionError, ":on" unless (options[:on] && options[:on].is_a?(Regexp)) || respond_to?(:default_on, true)
       @action, @on = options[:action], options[:on]
       @place = options[:place] if options[:place]
       @name = options[:name] if options[:name]


### PR DESCRIPTION
Ruby 2.0 changed respond_to? so that it only returns true for `public`
methods by default (in earlier version it was true for both `public` and
`protected` methods).
- http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html
