### PR TITLE
Fix require readline bug. When using gem rb-readline, require 'readline'...

### DIFF
--- a/lib/bond/readlines/ruby.rb
+++ b/lib/bond/readlines/ruby.rb
@@ -1,7 +1,7 @@
 # A pure ruby readline which requires {rb-readline}[https://github.com/luislavena/rb-readline].
 class Bond::Ruby < Bond::Readline
   def self.readline_setup
-    require 'rb-readline'
+    require 'readline'
   rescue LoadError
     abort "Bond Error: rb-readline gem is required for this readline plugin" +
       " -> gem install rb-readline"


### PR DESCRIPTION
... not 'rb-readline'
